### PR TITLE
classic warrior: fix execute threat modifier

### DIFF
--- a/ClassModules/Classic/Warrior.lua
+++ b/ClassModules/Classic/Warrior.lua
@@ -160,7 +160,7 @@ function Warrior:ClassInit()
 
 	-- Ability damage modifiers
 	for k, v in pairs(threatValues.execute) do
-		self.AbilityHandlers[v] = self.Execute
+		self.AbilityHandlers[k] = self.Execute
 	end
 
 	-- Shouts


### PR DESCRIPTION
Problem became apparent when threat displayed by Details! was not corresponding to mobs aggro mechanics in our MC raid.
This change fixes the small code issue that turns Execute modifier unreachable - making it 1.0 instead of 1.25. Note that I do not have data apart from anecdotal on actual Execute threat modifier.