### PR TITLE
Initial implementation of blizzard onyxia hotfix to fireball threat

### DIFF
--- a/ClassModules/Classic/Warrior.lua
+++ b/ClassModules/Classic/Warrior.lua
@@ -160,7 +160,7 @@ function Warrior:ClassInit()
 
 	-- Ability damage modifiers
 	for k, v in pairs(threatValues.execute) do
-		self.AbilityHandlers[v] = self.Execute
+		self.AbilityHandlers[k] = self.Execute
 	end
 
 	-- Shouts

--- a/ClassModules/Classic/Warrior.lua
+++ b/ClassModules/Classic/Warrior.lua
@@ -160,7 +160,7 @@ function Warrior:ClassInit()
 
 	-- Ability damage modifiers
 	for k, v in pairs(threatValues.execute) do
-		self.AbilityHandlers[k] = self.Execute
+		self.AbilityHandlers[v] = self.Execute
 	end
 
 	-- Shouts

--- a/NPCModules/Onyxia/Onyxia.lua
+++ b/NPCModules/Onyxia/Onyxia.lua
@@ -1,0 +1,20 @@
+local ThreatLib = LibStub and LibStub("ThreatClassic-1.0", true)
+if not ThreatLib then return end
+
+local ONYXIA_ID = 6109
+local ONYXIA_FIREBALL_SPELL = 18392
+
+
+ThreatLib:GetModule("NPCCore"):RegisterModule(
+    ONYXIA_ID, 
+    function(Onyxia)
+        function Onyxia:Init()
+            self:RegisterCombatant(ONYXIA_FIREBALL_SPELL, true)
+            self:RegisterSpellHandler("SPELL_DAMAGE", self.Fireball, ONYXIA_FIREBALL_SPELL, ONYXIA_FIREBALL_SPELL)
+        end
+
+        function Onyxia:Fireball()
+            self:WipeRaidThreatOnMob(ONYXIA_ID)
+        end
+    end
+)

--- a/NPCModules/Onyxia/Onyxia.lua
+++ b/NPCModules/Onyxia/Onyxia.lua
@@ -9,7 +9,7 @@ ThreatLib:GetModule("NPCCore"):RegisterModule(
     ONYXIA_ID, 
     function(Onyxia)
         function Onyxia:Init()
-            self:RegisterCombatant(ONYXIA_FIREBALL_SPELL, true)
+            self:RegisterCombatant(ONYXIA_ID, true)
             self:RegisterSpellHandler("SPELL_DAMAGE", self.Fireball, ONYXIA_FIREBALL_SPELL, ONYXIA_FIREBALL_SPELL)
         end
 


### PR DESCRIPTION
#### What's this do?
Clears threat of the primary target of an onyxia fireball.

#### Why are we doing this?
On november 8th Blizzard implemented a hotfix to clear threat on the primary target of a fireball.
This should correctly reflect the functionality of that hotfix.
https://www.wowhead.com/news=296156/wow-classic-november-8th-hotfixes-pvp-guard-behavior-onyxia-fireball-threat


#### Anything the reviewer(s) should know to review effectively?
Fireball spell ID per WoWhead classic -> https://classic.wowhead.com/spell=18392/fireball#see-also-other

#### Any questions for the reviewers?
I looked through the overall structure of the codebase and this seems like the best place for this? But I am not sure. Feel free to move it around as needed.

#### How should this be tested?
Verification in game - but I haven't spent much time testing or working on WoW addons. So, I'm not sure what your testing process might be.
