### PR TITLE
Add Wrath of Ragnaros raid reset wipe functionality

### DIFF
--- a/NPCModules/MoltenCore/Ragnaros.lua
+++ b/NPCModules/MoltenCore/Ragnaros.lua
@@ -1,0 +1,16 @@
+local ThreatLib = LibStub and LibStub("ThreatClassic-1.0", true)
+if not ThreatLib then return end
+
+local RAGNAROS_ID = 11502
+local WRATH_OF_RAGNAROS_ID = 20566
+
+ThreatLib:GetModule("NPCCore"):RegisterModule(RAGNAROS_ID, function(Ragnaros)
+	function Ragnaros:Init()
+		self:RegisterCombatant(RAGNAROS_ID, true)
+		self:RegisterSpellHandler("SPELL_CAST_SUCCESS", self.WrathOfRagnaros, WRATH_OF_RAGNAROS_ID)
+	end
+
+	function Ragnaros:WrathOfRagnaros()
+		self:WipeRaidThreatOnMob(RAGNAROS_ID)
+	end
+end)

--- a/ThreatNPCModuleCore.lua
+++ b/ThreatNPCModuleCore.lua
@@ -190,7 +190,7 @@ local threeQuarterThreat = function(mob, target) ModifyThreat(mob, target, 0.75,
 local threatThreeQuarterSpellIDs = {
 	-- 25778, -- Void Reaver, Fathom Lurker, Fathom Sporebat, Underbog Lord, Knock Away
 	-- 19633, -- Onyxia, Knock Away
-	20566, -- Ragnaros, Wrath of Ragnaros
+	-- 20566, -- Ragnaros, Wrath of Ragnaros. On Classic it does an entire raid threat reset
 	40486, -- Gurtogg Bloodboil, Eject (we ignore spellID 40597 which has a stun component rather than a knock back component)
 }
 


### PR DESCRIPTION
According to various reddit posts / discord talk the Wrath of Ragnaros ability does a threat wipe on the entire raid when it hits.

- Added Ragnaros NPC module
- Added listener to reset raid threat for Ragnaros Wrath of Ragnaros similar to Shazzrah Gate wipe